### PR TITLE
Acumula descrição dos filtros ao invés de exibir apenas a do último aplicado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 node_modules/
 src/css/style.css
+
+.tool-versions

--- a/src/js/modules/mod-viz.js
+++ b/src/js/modules/mod-viz.js
@@ -341,7 +341,7 @@ module.exports = function() {
     if (filterType != "") {
       animateRemoved(prevBlock, removed);
       h2Title = selectedOption.innerHTML;
-      text = getDescription(filterType, filteredData.length);
+      text = getDescription(filteredData.length);
       updateCurrentGender(filterType);
     }
 
@@ -1241,36 +1241,67 @@ module.exports = function() {
     }
   };
 
-  let getDescription = function(filterType, amount) {
+  let getDescription = function(amount) {
     let prep = { m: "Destes", f: "Destas" };
+
+    let personDescription = getFiltersDescriptionRelatedToPerson(
+      window.contextFilters,
+      amount
+    );
+
+    let politicalCareerDescription = getFilterDescriptionRelatedToPoliticalCareer(
+      window.contextFilters,
+      amount
+    );
+
     let phrase =
       prep[currGender] +
       ", <b>" +
       amount +
       "</b> " +
-      getFilterDescription(filterType, amount);
+      personDescription +
+      " " +
+      (personDescription && politicalCareerDescription ? "que " : "") +
+      politicalCareerDescription;
 
     return phrase;
   };
 
-  let getFilterDescription = function(filterType, amount) {
+  let getFiltersDescriptionRelatedToPerson = function(filters, amount) {
+    if (
+      !["mulheres", "homens", "brancos", "negros ou pardos"].some(value =>
+        filters.includes(value)
+      )
+    )
+      return "";
+
+    let phrase = amount > 1 ? "são" : "é";
+
+    if (filters.includes("mulheres")) {
+      phrase += amount > 1 ? " mulheres" : " mulher";
+    } else if (filters.includes("homens")) {
+      phrase += amount > 1 ? " homens" : " homem";
+    }
+
+    if (filters.includes("negros ou pardos")) {
+      phrase += " de cor negra, parda ou indígena";
+    } else if (filters.includes("brancos")) {
+      phrase += " de cor branca";
+    }
+
+    return phrase;
+  };
+
+  let getFilterDescriptionRelatedToPoliticalCareer = function(filters, amount) {
+    const filterApplied = filters
+      .reverse()
+      .find(element =>
+        ["nunca concorreram", "nunca eleitos", "já eleitos"].includes(element)
+      );
+
+    if (!filterApplied) return "";
+
     return {
-      mulheres: {
-        plural: "são mulheres",
-        singular: "é mulher"
-      },
-      homens: {
-        plural: "são homens",
-        singular: "é homem"
-      },
-      "negros ou pardos": {
-        plural: "são de cor negra, parda ou indígena",
-        singular: "é de cor negra, parda ou indígena"
-      },
-      brancos: {
-        plural: "são de cor branca",
-        singular: "é de cor branca"
-      },
       "nunca concorreram": {
         plural: "nunca concorreram numa eleição",
         singular: "nunca concorreu numa eleição"
@@ -1283,7 +1314,7 @@ module.exports = function() {
         plural: "já se elegeram anteriormente",
         singular: "já se elegeu"
       }
-    }[filterType][amount > 1 ? "plural" : "singular"];
+    }[filterApplied][amount > 1 ? "plural" : "singular"];
   };
 
   let updateCurrentGender = function(filterType) {

--- a/src/js/modules/mod-viz.js
+++ b/src/js/modules/mod-viz.js
@@ -342,6 +342,7 @@ module.exports = function() {
       animateRemoved(prevBlock, removed);
       h2Title = selectedOption.innerHTML;
       text = getDescription(filterType, filteredData.length);
+      updateCurrentGender(filterType);
     }
 
     if (filteredData.length == 0) {
@@ -1247,7 +1248,6 @@ module.exports = function() {
     if (amount > 1) {
       if (filterType == "mulheres") {
         phrase += "são mulheres";
-        currGender = "f";
       } else if (filterType == "homens") {
         phrase += "são homens";
       } else if (filterType == "nunca concorreram") {
@@ -1264,11 +1264,9 @@ module.exports = function() {
     } else {
       if (filterType == "mulheres") {
         phrase += "é mulher";
-        currGender = "f";
       }
       if (filterType == "homens") {
         phrase += "é homem";
-        currGender = "m";
       } else if (filterType == "nunca concorreram") {
         phrase += "nunca concorreu numa eleição";
       } else if (filterType == "nunca eleitos") {
@@ -1283,6 +1281,15 @@ module.exports = function() {
     }
 
     return phrase;
+  };
+
+  let updateCurrentGender = function(filterType) {
+    const genders = {
+      mulheres: "f",
+      homens: "m"
+    };
+
+    currGender = genders[filterType] || currGender;
   };
 
   let dispatchEvent = function(target, evt) {

--- a/src/js/modules/mod-viz.js
+++ b/src/js/modules/mod-viz.js
@@ -1241,64 +1241,44 @@ module.exports = function() {
   };
 
   let getDescription = function(filterType, amount) {
-    let phrase = "";
     let prep = { m: "Destes", f: "Destas" };
+    let phrase = prep[currGender] + ", <b>" + amount + "</b> ";
 
     if (amount > 1) {
       if (filterType == "mulheres") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> são mulheres";
+        phrase += "são mulheres";
         currGender = "f";
       } else if (filterType == "homens") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> são homens";
+        phrase += "são homens";
       } else if (filterType == "nunca concorreram") {
-        phrase =
-          prep[currGender] +
-          ", <b>" +
-          amount +
-          "</b> nunca concorreram numa eleição";
+        phrase += "nunca concorreram numa eleição";
       } else if (filterType == "nunca eleitos") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> nunca se elegeram";
+        phrase += "nunca se elegeram";
       } else if (filterType == "já eleitos") {
-        phrase =
-          prep[currGender] +
-          ", <b>" +
-          amount +
-          "</b> já se elegeram anteriormente";
+        phrase += "já se elegeram anteriormente";
       } else if (filterType == "negros ou pardos") {
-        phrase =
-          prep[currGender] +
-          ", <b>" +
-          amount +
-          "</b> são de cor negra, parda ou indígena";
+        phrase += "são de cor negra, parda ou indígena";
       } else if (filterType == "brancos") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> são de cor branca";
+        phrase += "são de cor branca";
       }
     } else {
       if (filterType == "mulheres") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> é mulher";
+        phrase += "é mulher";
         currGender = "f";
       }
       if (filterType == "homens") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> é homem";
+        phrase += "é homem";
         currGender = "m";
       } else if (filterType == "nunca concorreram") {
-        phrase =
-          prep[currGender] +
-          ", <b>" +
-          amount +
-          "</b> nunca concorreu numa eleição";
+        phrase += "nunca concorreu numa eleição";
       } else if (filterType == "nunca eleitos") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> nunca se elegeu";
+        phrase += "nunca se elegeu";
       } else if (filterType == "já eleitos") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> já se elegeu";
+        phrase += "já se elegeu";
       } else if (filterType == "negros ou pardos") {
-        phrase =
-          prep[currGender] +
-          ", <b>" +
-          amount +
-          "</b> é de cor negra, parda ou indígena";
+        phrase += "é de cor negra, parda ou indígena";
       } else if (filterType == "brancos") {
-        phrase = prep[currGender] + ", <b>" + amount + "</b> é de cor branca";
+        phrase += "é de cor branca";
       }
     }
 

--- a/src/js/modules/mod-viz.js
+++ b/src/js/modules/mod-viz.js
@@ -1243,44 +1243,47 @@ module.exports = function() {
 
   let getDescription = function(filterType, amount) {
     let prep = { m: "Destes", f: "Destas" };
-    let phrase = prep[currGender] + ", <b>" + amount + "</b> ";
-
-    if (amount > 1) {
-      if (filterType == "mulheres") {
-        phrase += "são mulheres";
-      } else if (filterType == "homens") {
-        phrase += "são homens";
-      } else if (filterType == "nunca concorreram") {
-        phrase += "nunca concorreram numa eleição";
-      } else if (filterType == "nunca eleitos") {
-        phrase += "nunca se elegeram";
-      } else if (filterType == "já eleitos") {
-        phrase += "já se elegeram anteriormente";
-      } else if (filterType == "negros ou pardos") {
-        phrase += "são de cor negra, parda ou indígena";
-      } else if (filterType == "brancos") {
-        phrase += "são de cor branca";
-      }
-    } else {
-      if (filterType == "mulheres") {
-        phrase += "é mulher";
-      }
-      if (filterType == "homens") {
-        phrase += "é homem";
-      } else if (filterType == "nunca concorreram") {
-        phrase += "nunca concorreu numa eleição";
-      } else if (filterType == "nunca eleitos") {
-        phrase += "nunca se elegeu";
-      } else if (filterType == "já eleitos") {
-        phrase += "já se elegeu";
-      } else if (filterType == "negros ou pardos") {
-        phrase += "é de cor negra, parda ou indígena";
-      } else if (filterType == "brancos") {
-        phrase += "é de cor branca";
-      }
-    }
+    let phrase =
+      prep[currGender] +
+      ", <b>" +
+      amount +
+      "</b> " +
+      getFilterDescription(filterType, amount);
 
     return phrase;
+  };
+
+  let getFilterDescription = function(filterType, amount) {
+    return {
+      mulheres: {
+        plural: "são mulheres",
+        singular: "é mulher"
+      },
+      homens: {
+        plural: "são homens",
+        singular: "é homem"
+      },
+      "negros ou pardos": {
+        plural: "são de cor negra, parda ou indígena",
+        singular: "é de cor negra, parda ou indígena"
+      },
+      brancos: {
+        plural: "são de cor branca",
+        singular: "é de cor branca"
+      },
+      "nunca concorreram": {
+        plural: "nunca concorreram numa eleição",
+        singular: "nunca concorreu numa eleição"
+      },
+      "nunca eleitos": {
+        plural: "nunca se elegeram",
+        singular: "nunca se elegeu"
+      },
+      "já eleitos": {
+        plural: "já se elegeram anteriormente",
+        singular: "já se elegeu"
+      }
+    }[filterType][amount > 1 ? "plural" : "singular"];
   };
 
   let updateCurrentGender = function(filterType) {


### PR DESCRIPTION
Closes #35 

Para acumular as descrições separei as descrições dos filtros em dois grupos: as descrições sobre a pessoa (genero e etnia) e a descrição da carreira política.

Genero e etnia são cumulativos, optei por usar sempre a mesma ordem, primeiro genero e depois etnia, na frase (não importando a ordem do filtro). Então, aplicando os filtros `Quantas são mulheres?` e depois `Quantos são negros ou pardos?` <a href="#ex-1">(Exemplo 1)</a> exibe a mesma descrição que aplicando `Quantos são negros ou pardos?` e depois `Quantas são mulheres?`.

Já os filtros relacionados a carreira política, apesar de nunca concorreram ser um subgrupo de nunca se elegeram, não acumulei a descrição desses porque acho que se aplicarem os dois, é melhor descrever apenas com o grupo menor <a href="#ex-2">(Exemplo 2)</a>.

Para juntar a descrição da pessoa com a descrição da carreira política coloquei um `"que"` entre eles <a href="#ex-3">(Exemplo 3)</a>. 

<h4 id="ex-1">Exemplo 1:</h4>

Aplicando as perguntas:
- `Quantas são mulheres?`
- `Quantos são negros ou pardos?`

O resultado é: `Destas, 157 são mulheres de cor negra, parda ou indígena`

-----------------

<h4 id="ex-2">Exemplo 2:</h4>

Aplicando as perguntas:
- `Quantos nunca foram eleitos?`
- `Quantos nunca concorreram?`

O resultado é `Destes, 726 nunca concorreram numa eleição`


-----

<h4 id="ex-3">Exemplo 3:</h4>

Aplicando as perguntas:
- `Quantos nunca concorreram?`
- `Quantas são mulheres?`

O resultado é `Destes, 281 são mulheres que nunca se elegeram`



