### PR TITLE
Altera a ordem de exibição do histórico de candidaturas

### DIFF
--- a/src/html/index.html.hbs
+++ b/src/html/index.html.hbs
@@ -127,15 +127,15 @@
                 </h4>
 
                 <div id="election-history">
-                    <button class="history-year y2018">2018</button>
-                    <button class="history-year y2016">2016</button>
-                    <button class="history-year y2014">2014</button>
-                    <button class="history-year y2012">2012</button>
-                    <button class="history-year y2010">2010</button>
-                    <button class="history-year y2008">2008</button>
-                    <button class="history-year y2006">2006</button>
-                    <button class="history-year y2004">2004</button>
                     <button class="history-year y2002">2002</button>
+                    <button class="history-year y2004">2004</button>
+                    <button class="history-year y2006">2006</button>
+                    <button class="history-year y2008">2008</button>
+                    <button class="history-year y2010">2010</button>
+                    <button class="history-year y2012">2012</button>
+                    <button class="history-year y2014">2014</button>
+                    <button class="history-year y2016">2016</button>
+                    <button class="history-year y2018">2018</button>     
                 </div>
 
                 <div id="election-text">


### PR DESCRIPTION
Coloca em ordem crescente o histórico de candidaturas

<img width="956" alt="Screenshot 2021-10-18 at 14 51 40" src="https://user-images.githubusercontent.com/62898120/137734341-f2462c92-ef23-41a5-b6b1-ef3d0e6e859f.png">
Antes estava de 2018 a 2002

Solves #36 