### PR TITLE
Alteracoes busca historico e status

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -117,7 +117,7 @@
                     (showListCandidates = false)
                 "
               >
-                <span class="w-full capitalize">{{ candidate.name }} </span>
+                <span class="w-full capitalize">{{ candidate.name }} ({{ candidate.party }})</span>
               </li>
               <li
                 v-if="searchListCandidates && !filteredList.length"

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -29,7 +29,7 @@
           id="roleCandidates"
           name="roleCandidates"
           @change="selectRoleNavbar"
-          class="bg-white bg-opacity-10 h-full p-3 text-white text-sm rounded-l-lg border-transparent font-regular focus:ring-secondary-base focus:border-secondary-base block"
+          class=" bg-background-purpleLight bg-opacity-70 h-full p-3 text-white text-sm rounded-l-lg border-transparent font-regular focus:ring-secondary-base focus:border-secondary-base block"
           placeholder="Cargo"
           required
         >

--- a/src/views/Candidate/Timeline.vue
+++ b/src/views/Candidate/Timeline.vue
@@ -1,29 +1,26 @@
 <template>
   <ol class="relative border-l border-gray-200">
-    <li class="mb-10 ml-4" v-for="item of data" :key="item">
-      <div
-        class="absolute w-3 h-3 bg-secondary-base rounded-full mt-1.5 -left-1.5"
-      ></div>
-      <time
-        class="mb-2 text-base font-bold text-primary-base flex items-center"
-      >
-        <span class="mr-3">{{ item.year }}</span>
-        <span
-          v-if="item.result === 'ELEITO'"
-          class="bg-primary-base rounded-2xl text-white py-1 px-2 text-xs"
-          >Eleito (a)</span
+    <template v-for="item of data.slice().reverse()" :key="item">
+      <li class="mb-10 ml-4" v-if="item.result !== '2O TURNO'">
+        <div
+          class="absolute w-3 h-3 bg-secondary-base rounded-full mt-1.5 -left-1.5"
+        ></div>
+        <time
+          class="mb-2 text-base font-bold text-primary-base flex items-center"
         >
-        <span
-          v-if="item.result === '2O TURNO'"
-          class="bg-primary-base rounded-2xl text-white py-1 px-2 text-xs"
-          >2º Turno</span
-        >
-      </time>
-      <p class="mb-4 text-xs text-text-light font-regular">
-        Candidatou-se ao cargo de
-        <span class="capitalize">{{ item.post }}</span>
-      </p>
-    </li>
+          <span class="mr-3">{{ item.year }}</span>
+          <span
+            v-if="item.elected === true"
+            class="bg-primary-base rounded-2xl text-white py-1 px-2 text-xs"
+            >Eleito(a)</span
+          >
+        </time>
+        <p class="mb-4 text-xs text-text-light font-regular">
+          Candidatou-se ao cargo de
+          <span class="capitalize">{{ item.post }}</span>
+        </p>
+      </li>
+    </template>
   </ol>
 </template>
 

--- a/src/views/Home/FormSearchCandidate.vue
+++ b/src/views/Home/FormSearchCandidate.vue
@@ -104,7 +104,7 @@
                     (showListCandidates = false)
                 "
               >
-                <span class="w-full capitalize">{{ candidate.name }} </span>
+                <span class="w-full capitalize">{{ candidate.name }} ({{ candidate.party }})</span>
               </li>
               <li
                 v-if="searchListCandidates && !filteredList.length"


### PR DESCRIPTION
@vanessa-nascimento mexi em algumas coisas. Qualquer uma que atrapalhar aí, posso deletar o commit tranquilamente:

1. Histórico de candidaturas mostrava segundo turno e não mostrava resultados de eleição corretamente em alguns casos

O histórico com segundo turno ficava um pouco confuso pois o segundo turno vinha antes e caso a pessoa não fosse eleita ficavam duas linhas. Removi as linhas de segundo turno, considerando apenas resultados "eleitos" ou "não eleitos". E utilizando o booleano `elected` pois no `result` há resultados como `'ELEITO POR QP'` (eleições majoritárias como a de deputado estadual) e coisas do tipo.

| Antes | Depois |
| -- | -- |
| ![localhost_8080_pessoa-candidata_2022_pe_deputado-estadual_2944981](https://user-images.githubusercontent.com/26327506/190459745-f58740a7-700a-4bf5-b7e6-6a3cc3c39e60.png) | ![localhost_8080_pessoa-candidata_2022_pe_deputado-estadual_2944981 (1)](https://user-images.githubusercontent.com/26327506/190462421-0adbd3d8-d3b0-464e-8639-d18df64e0826.png) |


2. Cor do seletor de cargo na navbar estava ficando branca e sem leitura

Coloquei uma cor bem parecida baseada na purpleLight com opacidade reduzida e deu uma leitura melhor.

| Antes | Depois |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/26327506/190458628-5c3ad985-1789-4214-8973-30adc7811f6f.png) | ![image](https://user-images.githubusercontent.com/26327506/190461045-1af7dd2b-012c-4369-9b78-f3ff08e20faf.png) |

3. Nome na busca retornava sem partido

| Antes | Depois |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/26327506/190458790-2b56cf8f-a035-404a-8dd9-e8c3731f170e.png) | ![image](https://user-images.githubusercontent.com/26327506/190464013-b41d3d69-2947-4452-910a-8dcd2fa9182e.png) |



